### PR TITLE
Remove unneeded code that was causing error

### DIFF
--- a/build/heatmap.js
+++ b/build/heatmap.js
@@ -524,7 +524,6 @@ var Canvas2dRenderer = (function Canvas2dRendererClosure() {
 
       }
 
-      img.data = imgData;
       this.ctx.putImageData(img, x, y);
 
       this._renderBoundaries = [1000, 1000, 0, 0];


### PR DESCRIPTION
Error: Cannot assign to read only property 'data' of object '[object ImageData]'

This error appears to be related to the update of the TS library used in project. Fix has been identified but PR hasn't been merged in original project.